### PR TITLE
Fix for the Transaction field containing the Client object

### DIFF
--- a/src/main/java/de/paymill/model/Client.java
+++ b/src/main/java/de/paymill/model/Client.java
@@ -3,13 +3,13 @@ package de.paymill.model;
 import java.util.Date;
 import java.util.List;
 
-public class Client {
+public class Client implements IPaymillObject {
 	private String id;
 	private String description;
 	private String email;
 	private Date createdAt;
 	private Date updatedAt;
-	private List<Payment> payments;
+	private List<Payment> payment;
 	private List<Subscription> subscription;
 
 	/**
@@ -90,16 +90,16 @@ public class Client {
 	/**
 	 * @return the payments
 	 */
-	public List<Payment> getPayments() {
-		return payments;
+	public List<Payment> getPayment() {
+		return payment;
 	}
 
 	/**
 	 * @param payments
 	 *            the payments to set
 	 */
-	public void setPayments(List<Payment> payments) {
-		this.payments = payments;
+	public void setPayment(List<Payment> payments) {
+		this.payment = payments;
 	}
 
 	/**

--- a/src/main/java/de/paymill/model/IPaymillObject.java
+++ b/src/main/java/de/paymill/model/IPaymillObject.java
@@ -1,0 +1,6 @@
+package de.paymill.model;
+
+public interface IPaymillObject {
+
+	String getId();
+}

--- a/src/main/java/de/paymill/model/Offer.java
+++ b/src/main/java/de/paymill/model/Offer.java
@@ -2,7 +2,7 @@ package de.paymill.model;
 
 import java.util.Date;
 
-public class Offer {
+public class Offer implements IPaymillObject {
 	public enum Interval {
 		WEEK, MONTH, YEAR
 	}

--- a/src/main/java/de/paymill/model/Payment.java
+++ b/src/main/java/de/paymill/model/Payment.java
@@ -2,7 +2,7 @@ package de.paymill.model;
 
 import java.util.Date;
 
-public class Payment {
+public class Payment implements IPaymillObject {
 	private String id;
 	private Type type;
 	private String client;

--- a/src/main/java/de/paymill/model/Refund.java
+++ b/src/main/java/de/paymill/model/Refund.java
@@ -2,7 +2,7 @@ package de.paymill.model;
 
 import java.util.Date;
 
-public class Refund {
+public class Refund implements IPaymillObject {
 
 	public enum Status {
 		OPEN, REFUNDED, FAILED

--- a/src/main/java/de/paymill/model/Subscription.java
+++ b/src/main/java/de/paymill/model/Subscription.java
@@ -2,7 +2,7 @@ package de.paymill.model;
 
 import java.util.Date;
 
-public class Subscription {
+public class Subscription implements IPaymillObject {
 	private String id;
 	private Offer offer;
 	private Client client;

--- a/src/main/java/de/paymill/model/Transaction.java
+++ b/src/main/java/de/paymill/model/Transaction.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 /**
  */
-public class Transaction {
+public class Transaction implements IPaymillObject {
 	public enum Status {
 		PARTIAL_REFUNDED, REFUNDED, CLOSED, FAILED, PENDING;
 	}

--- a/src/main/java/de/paymill/net/UrlEncoder.java
+++ b/src/main/java/de/paymill/net/UrlEncoder.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import de.paymill.PaymillException;
+import de.paymill.model.IPaymillObject;
 
 /**
  * Encoder implementation which returns url encoded query strings when encoding
@@ -132,6 +133,10 @@ public class UrlEncoder implements IEncoder {
 			if (value instanceof Enum) {
 				Enum<?> e = (Enum<?>)value;
 				value = e.toString().toLowerCase();
+			}
+			if(value instanceof IPaymillObject)
+			{
+				value = ((IPaymillObject) value).getId();
 			}
 			builder.append(
 				String.format("%s=%s",


### PR DESCRIPTION
With the name `customer` of the `Transaction` property it was not recognized by GSON and therefore not parsed as in the JSON response it is called `client`.

Simply renaming the field to `client` and regenerating the getter and setter accordingly fixes this problem.

The travis builds fail because of assumptions about the test servers to reach ...
