### PR TITLE
Bug fix sun.misc.BASE64Encoder proprietary

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,11 @@
 			<version>4.10</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+		  <groupId>commons-codec</groupId>
+		  <artifactId>commons-codec</artifactId>
+		  <version>1.7</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>
@@ -43,7 +48,7 @@
 			</plugin>
 		</plugins>
 	</build>
-	<version>2.0</version>
+	<version>2.1.snapshot</version>
 	<organization>
 		<name>Paymill GmbH</name>
 		<url>http://www.paymill.com</url>

--- a/src/main/java/de/paymill/net/HttpClient.java
+++ b/src/main/java/de/paymill/net/HttpClient.java
@@ -10,7 +10,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
 
-import sun.misc.BASE64Encoder;
+import org.apache.commons.codec.binary.Base64;
+
 import de.paymill.PaymillException;
 
 /**
@@ -216,9 +217,7 @@ public class HttpClient {
 
 	protected void setAuthentication(HttpURLConnection connection) {
 		String authInfo = apiKey + ":";
-		// TODO remove proprietary base64 encoder
-		BASE64Encoder encoder = new BASE64Encoder();
-		String encodedAuth = encoder.encode(authInfo.getBytes());
+		String encodedAuth = Base64.encodeBase64String(authInfo.getBytes());
 		connection.setRequestProperty("Authorization", "Basic " + encodedAuth);
 	}
 


### PR DESCRIPTION
Replaced 

sun.misc.BASE64Encoder

with 

http://commons.apache.org/codec/apidocs/org/apache/commons/codec/binary/Base64.html

as described in

https://github.com/Paymill/Paymill-Java/issues/3
