### PR TITLE
Added PaymentService.create(token, client) and test for failing deletions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 target
 .classpath
 .project
+.settings
+bin
+dist
+build.xml

--- a/src/main/java/de/paymill/service/PaymentService.java
+++ b/src/main/java/de/paymill/service/PaymentService.java
@@ -6,6 +6,7 @@ package de.paymill.service;
 import java.util.HashMap;
 import java.util.Map;
 
+import de.paymill.model.Client;
 import de.paymill.model.Payment;
 import de.paymill.net.HttpClient;
 
@@ -28,5 +29,15 @@ public class PaymentService extends AbstractService<Payment> {
 		params.put("token", token);
 		return client.post(resource, params, modelClass);
 	}
+
+	// Documented here, but missing
+	// https://www.paymill.com/it-it/documentation-3/reference/api-reference/index.html#create-new-credit-card-payment-with
+	// Not having this method, will cause problem during subscription management (eg, duplicate clients).
+    public Payment create(String token, Client client) {
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("token", token);
+        params.put("client", client.getId());
+        return this.client.post(resource, params, modelClass);
+    }
 
 }

--- a/src/test/java/de/paymill/service/PaymentServiceTest.java
+++ b/src/test/java/de/paymill/service/PaymentServiceTest.java
@@ -2,6 +2,7 @@ package de.paymill.service;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
@@ -12,31 +13,51 @@ import de.paymill.model.Payment.Type;
 
 public class PaymentServiceTest extends TestCase {
 
-	@Test
-	public void testCreateCard() {
-		PaymentService srv = Paymill.getService(PaymentService.class);
-		String token = getToken();
+    @Test
+    public void testCreateCard() {
+        PaymentService srv = Paymill.getService(PaymentService.class);
+        String token = getToken();
 
-		Payment payment = srv.create(token);
+        Payment payment = srv.create(token);
 
-		assertNotNull(payment);
-		assertNotNull(payment.getId());
-		assertEquals("1111", payment.getLast4());
-	}
+        assertNotNull(payment);
+        assertNotNull(payment.getId());
+        assertEquals("1111", payment.getLast4());
+    }
 
-	@Test
-	public void testCreateDebit() {
-		PaymentService srv = Paymill.getService(PaymentService.class);
+    @Test
+    public void testCreateDebit() {
+        PaymentService srv = Paymill.getService(PaymentService.class);
 
-		Payment params = new Payment();
-		params.setType(Type.DEBIT);
-		params.setAccount("123456");
-		params.setCode("12345678");
-		params.setHolder("jon doe");
-		Payment payment = srv.create(params);
+        Payment params = new Payment();
+        params.setType(Type.DEBIT);
+        params.setAccount("123456");
+        params.setCode("12345678");
+        params.setHolder("jon doe");
+        Payment payment = srv.create(params);
 
-		assertNotNull(payment);
-		assertNotNull(payment.getId());
-		assertEquals("**3456", payment.getAccount());
-	}
+        assertNotNull(payment);
+        assertNotNull(payment.getId());
+        assertEquals("**3456", payment.getAccount());
+    }
+
+    @Test
+    public void testDeletePayment() {
+        PaymentService srv = Paymill.getService(PaymentService.class);
+        String token = getToken();
+
+        Payment payment = srv.create(token);
+
+        assertNotNull(payment);
+        assertNotNull(payment.getId());
+        assertEquals("1111", payment.getLast4());
+
+        try {
+            srv.delete(payment);
+        } catch (NullPointerException e) {
+            fail("Deletion should be successful");
+            e.printStackTrace(); // Null Pointer Exception
+        }
+    }
+
 }


### PR DESCRIPTION
In this pull request I implemented the method PaymentService.create(token, client). It is documented here https://www.paymill.com/it-it/documentation-3/reference/api-reference/index.html#create-new-credit-card-payment-with but it was not implemented.

I also created a test case for failing payment deletions in PaymentServiceTest. I have the feelings that deletions fail for every entity, but I have not extensively tested it. It explodes with a NullPointerException in a common class, so probably it affects every deletions (the Travis build is failing because of this new test). Git sees a full edit for this class but I actually only added the testDeletePayment method.

I also had to include some (common) entries in the .gitingore file to avoid pushing IDE-related files.
