### PR TITLE
Added constructors to Client and Payment to accept id as parameter

### DIFF
--- a/src/main/java/de/paymill/model/Client.java
+++ b/src/main/java/de/paymill/model/Client.java
@@ -12,6 +12,17 @@ public class Client implements IPaymillObject {
 	private List<Payment> payment;
 	private List<Subscription> subscription;
 
+	public Client() {
+	}
+
+	/**
+	 * @param id
+	 *            the id to set
+	 */
+	public Client(String id) {
+		this.id = id;
+	}
+
 	/**
 	 * @return the id
 	 */

--- a/src/main/java/de/paymill/model/Payment.java
+++ b/src/main/java/de/paymill/model/Payment.java
@@ -22,6 +22,17 @@ public class Payment implements IPaymillObject {
 		CREDITCARD, DEBIT;
 	}
 
+	public Payment() {
+	}
+
+	/**
+	 * @param id
+	 *            the id to set
+	 */
+	public Payment(String id) {
+		this.id = id;
+	}
+
 	/**
 	 * @return the id
 	 */


### PR DESCRIPTION
Hi, I've added some constructor to allow a more fluid syntax while building objects for transactions. The new constructors accept the id of the object as parameter (and I had to add also the default constructor because of the override).

For a transaction you usually need Client and Payment objects, adding these constructor allows for a more fluid syntax like:

```
Transaction tx = new Transaction();
tx.setClient(new Client(user.getClientId()));
tx.setPayment(new Payment(user.getPaymentId()));
tx.setAmount(amount);
```

instead of having to create objects and then call the setter methods.

For one-off usage this is easier.
