### PR TITLE
Refactored the Paymill class to make it easier to use multiple api keys

### DIFF
--- a/src/main/java/de/paymill/Paymill.java
+++ b/src/main/java/de/paymill/Paymill.java
@@ -76,13 +76,24 @@ public class Paymill {
 	 */
 	public static <T extends AbstractService<?>> T getService(
 			Class<T> serviceClass) {
-		try {
-			Constructor<T> c = serviceClass.getConstructor(HttpClient.class);
-			return c.newInstance(getClient());
-		} catch (Exception ex) {
-			throw new PaymillException(
-					"Error creating a new instance of service " + serviceClass,
-					ex);
-		}
+		return getService(serviceClass, getApiKey());
 	}
+
+    /**
+     * Creates a new api service object instance with a special apiKey.
+     *
+     * @param serviceClass
+     * @return
+     */
+    public static <T extends AbstractService<?>> T getService(
+            Class<T> serviceClass, String apiKey) {
+        try {
+            Constructor<T> c = serviceClass.getConstructor(HttpClient.class);
+            return c.newInstance(getClient(apiKey));
+        } catch (Exception ex) {
+            throw new PaymillException(
+                    "Error creating a new instance of service " + serviceClass,
+                    ex);
+        }
+    }
 }


### PR DESCRIPTION
Once I want to use multiple api keys to work on my own account and process transaction via Paymill Unite, the static apiKey varible is limiting my needs.
I externalized the gathering of the api key and I didn´t break any existing api.
