### PR TITLE
Change Offer setInterval method parameter type from String to Interval.Period type

### DIFF
--- a/src/main/java/com/paymill/models/Offer.java
+++ b/src/main/java/com/paymill/models/Offer.java
@@ -113,8 +113,8 @@ public final class Offer {
     return interval;
   }
 
-  public void setInterval( String interval ) {
-    this.interval = new Interval.Period( interval );
+  public void setInterval(Interval.Period interval) {
+    this.interval = interval;
   }
 
   public Offer.SubscriptionCount getSubscriptionCount() {

--- a/src/test/java/com/paymill/services/OfferServiceTest.java
+++ b/src/test/java/com/paymill/services/OfferServiceTest.java
@@ -110,7 +110,7 @@ public class OfferServiceTest {
     Assert.assertEquals( subscription.getOffer().getId(), offer.getId() );
     Assert.assertEquals( subscription.getInterval().getInterval(), (Integer) 1 );
     Assert.assertEquals( subscription.getInterval().getUnit(), Interval.Unit.MONTH );
-    offer.setInterval( "2 WEEK" );
+    offer.setInterval( new Interval.Period( "2 WEEK" ) );
     this.offerService.update( offer, true );
     Assert.assertEquals( offer.getId(), offer.getId() );
     Assert.assertEquals( offer.getInterval().getInterval(), (Integer) 2 );


### PR DESCRIPTION
There is an error getting an offer's interval property because the interval is not copied using the RestfulUtils.refreshInstance method. The error is due to the inconsistency between the types of interval's getter and setter methods.
