### PR TITLE
removed final keywoards from PaymillContext and ClientService

### DIFF
--- a/src/main/java/com/paymill/context/PaymillContext.java
+++ b/src/main/java/com/paymill/context/PaymillContext.java
@@ -39,7 +39,7 @@ import com.sun.jersey.api.client.filter.HTTPBasicAuthFilter;
  * @author Vassil Nikolov
  * @since 3.0.0
  */
-public final class PaymillContext {
+public class PaymillContext {
 
   public final static ObjectMapper PARSER     = new ObjectMapper();
   private final static Properties  PROPERTIES = new Properties();

--- a/src/main/java/com/paymill/services/ClientService.java
+++ b/src/main/java/com/paymill/services/ClientService.java
@@ -15,7 +15,7 @@ import com.sun.jersey.core.util.MultivaluedMapImpl;
  * @author Vassil Nikolov
  * @since 3.0.0
  */
-public final class ClientService extends AbstractService {
+public class ClientService extends AbstractService {
 
   private ClientService( com.sun.jersey.api.client.Client httpClient ) {
     super( httpClient );


### PR DESCRIPTION
In order to properly mock these classes they must not be final since popular mocking frameworks like Mockito don't allow mocking of final classes. 

Also, ClientService is the only service which is final so this PR removes this inconsistency.
