### PR TITLE
add missing status "failed" and "expired" in enum Subscription.Status

### DIFF
--- a/src/main/java/com/paymill/models/Subscription.java
+++ b/src/main/java/com/paymill/models/Subscription.java
@@ -493,7 +493,7 @@ public final class Subscription {
 
   public enum Status {
 
-    ACTIVE("active"), INACTIVE("inactive");
+    ACTIVE("active"), INACTIVE("inactive"), FAILED("failed"), EXPIRED("expired");
 
     private String value;
 


### PR DESCRIPTION
missing status leads to exception on deserialization.
